### PR TITLE
test(ProxyStakedKLAY): improve code coverage by adding test cases

### DIFF
--- a/test/CNStakedKLAY.ts
+++ b/test/CNStakedKLAY.ts
@@ -831,7 +831,7 @@ describe('CNStakedKLAY', () => {
     });
   });
 
-  describe('#setPeriodicStakingStatsDebounceInterval', () => {
+  describe('#setPeriodicStakingStatsDebounceInterval()', () => {
     it('should revert when called by non-owner', async () => {
       await expect(cnStakedKLAY.connect(accounts.bob).setPeriodicStakingStatsDebounceInterval(0)).to
         .be.reverted;

--- a/test/CNStakedKLAY.ts
+++ b/test/CNStakedKLAY.ts
@@ -376,9 +376,13 @@ describe('CNStakedKLAY', () => {
 
     describe('#stakeFor()', () => {
       it('should be able to stake for other account', async () => {
-        await cnStakedKLAY.for.bob.stakeFor(accounts.alice.address, { value: ETHER });
-        await expectBalanceOf(accounts.alice).to.equal(ETHER);
-        await expectBalanceOf(accounts.bob).to.equal(0n);
+        await expect(
+          cnStakedKLAY.for.bob.stakeFor(accounts.alice.address, { value: ETHER }),
+        ).to.changeTokenBalances(
+          cnStakedKLAY,
+          [accounts.alice.address, accounts.bob.address],
+          [ETHER, 0n],
+        );
       });
     });
 
@@ -583,11 +587,20 @@ describe('CNStakedKLAY', () => {
           await expectBalanceOf(accounts.alice).to.equal(0n);
         });
 
-        it('should not be able to unstake all if balance is 0', async () => {
+        it('should not be able to unstake all if balance is zero', async () => {
           await expect(cnStakedKLAY.for.bob.unstakeAll()).to.be.revertedWithCustomError(
             cnStakedKLAY,
             'AmountTooSmall',
           );
+        });
+
+        it('should sweep rewards', async () => {
+          await issueReward(ETHER);
+
+          await cnStakedKLAY.for.alice.unstakeAll();
+
+          await expectEtherBalanceOf(cnStakedKLAY).to.equal(0n);
+          await expectBalanceOf(accounts.alice).to.equal(0n);
         });
       });
 


### PR DESCRIPTION
## Summary

This PR
- adds test cases for
  - `stakeFor()`
  - `unstakeAll()`
  - `setPeriodicStakingStatsDebounceInterval()`

and all test cases passed!

## Coverage Results

```
--------------------------------|----------|----------|----------|----------|----------------|
File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
--------------------------------|----------|----------|----------|----------|----------------|
 contracts/                     |    92.19 |    67.54 |     91.8 |    90.76 |                |
  CNStakedKLAY.sol              |     87.5 |    83.33 |       80 |       92 |         41,136 |
  ERC20VotesCustomBalance.sol   |    78.72 |    56.67 |    84.21 |    78.57 |... 169,218,219 |
  ProxyStakedKLAY.sol           |      100 |    82.69 |      100 |    98.96 |            212 |
  ProxyStakedKLAYClaimCheck.sol |    94.23 |    46.15 |      100 |    88.89 |... 138,139,193 |
--------------------------------|----------|----------|----------|----------|----------------|
All files                       |    92.19 |    67.54 |     91.8 |    90.76 |                |
--------------------------------|----------|----------|----------|----------|----------------|
```