### PR TITLE
misc: add pre-commit hook to run lint and test

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "test": "hardhat test",
     "gas-report": "env REPORT_GAS=true yarn test",
     "coverage": "hardhat coverage",
+    "postinstall": "ln -sf \"$(pwd)/scripts/git/hooks/pre-commit.sh\" ./.git/hooks/pre-commit",
+    "precommit": "yarn lint && yarn test",
     "lint": "yarn lint:js && yarn lint:sol",
     "lint:fix": "yarn lint:js:fix && yarn lint:sol:fix",
     "lint:js": "prettier --loglevel warn --ignore-path .gitignore '**/*.{js,ts}' --check && eslint --ignore-path .gitignore .",

--- a/scripts/git/hooks/pre-commit.sh
+++ b/scripts/git/hooks/pre-commit.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+
+pushd "${DIR}/../../.."
+
+yarn precommit


### PR DESCRIPTION
This PR introduces git pre-commit hook that runs `yarn lint && yarn test`.

This is to prevent footgunning.