### PR TITLE
test(utils): remove unnecessary and buggy log prefix

### DIFF
--- a/test/CNStakedKLAY.ts
+++ b/test/CNStakedKLAY.ts
@@ -125,9 +125,9 @@ describe('CNStakedKLAY', () => {
         totalShares: await cnStakedKLAY.totalShares(),
         totalSupply: await cnStakedKLAY.totalSupply(),
       };
-      log.fromUtil(`## ${title} - cnStakedKLAY STATS`);
-      log.fromUtil(stats);
-      log.fromUtil(`## ${title} - cnStakedKLAY STATS END`);
+      log(`## ${title} - cnStakedKLAY STATS`);
+      log(stats);
+      log(`## ${title} - cnStakedKLAY STATS END`);
     };
   });
 

--- a/test/utils/useLogger.ts
+++ b/test/utils/useLogger.ts
@@ -1,25 +1,8 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import { stdout } from 'node:process';
 import util from 'node:util';
 
-const parsePathFromStack = (stack: string) => {
-  const [, filepath, row, col] = stack.match(/\((.+):([0-9]+):([0-9]+)\)$/) || [];
-  if (!filepath) {
-    const [, mfilepath, mrow, mcol] = stack.match(/at (.+):([0-9]+):([0-9]+)$/) || [];
-    if (!mfilepath) {
-      throw new Error('NO MATCH FOUND FOR ' + stack);
-    }
-    return { filepath: mfilepath, row: mrow, col: mcol };
-  }
-  return { filepath, row, col };
-};
-
 export const useLogger = ({ suppressOnSuccess = true } = {}) => {
-  const useLoggerFileLocation = path.dirname(
-    parsePathFromStack((new Error().stack ?? '').split('\n')[2].trim()).filepath,
-  );
-
   let buffer = '';
 
   afterEach(function () {
@@ -31,20 +14,13 @@ export const useLogger = ({ suppressOnSuccess = true } = {}) => {
   });
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const log = (msg: any, { stackOffset = 0 } = {}) => {
-    const { filepath, row, col } = parsePathFromStack(
-      (new Error().stack ?? '').split('\n')[2 + stackOffset].trim(),
-    );
-    const location = `${path.relative(useLoggerFileLocation, filepath)}:${row}:${col}`;
+  const log = (msg: any) => {
     buffer +=
       (typeof msg === 'string' ? msg : util.inspect(msg, { depth: null }))
         .split('\n')
-        .map((l) => `${location}> ${l}`)
+        .map((l) => `${l}`)
         .join('\n') + '\n';
   };
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  log.fromUtil = (msg: any) => log(msg, { stackOffset: 6 });
 
   return log;
 };


### PR DESCRIPTION
Filename prefix logic on `useLogger` is often floppy.

This PR removes this unnecessary prefix.