### PR TITLE
contracts: `ProxyStakedKLAY` to accept reward address

### DIFF
--- a/contracts/CNStakedKLAYV1.sol
+++ b/contracts/CNStakedKLAYV1.sol
@@ -16,6 +16,6 @@ contract CNStakedKLAYV1 is ProxyStakedKLAYUnstakeable, CNStakingV1Interface {
     string memory name,
     string memory symbol,
     address _feeTo,
-    CnStakingContract _cnStaking
-  ) CNStakingV1Interface(_cnStaking) ProxyStakedKLAY(_feeTo, name, symbol) {}
+    CnStakingContract newCnStaking
+  ) CNStakingV1Interface(newCnStaking) ProxyStakedKLAY(_feeTo, name, symbol) {}
 }

--- a/contracts/CNStakedKLAYV2.sol
+++ b/contracts/CNStakedKLAYV2.sol
@@ -16,6 +16,6 @@ contract CNStakedKLAYV2 is ProxyStakedKLAYUnstakeable, CNStakingV2Interface {
     string memory name,
     string memory symbol,
     address _feeTo,
-    CnStakingV2 _cnStaking
-  ) CNStakingV2Interface(_cnStaking) ProxyStakedKLAY(_feeTo, name, symbol) {}
+    CnStakingV2 newCnStaking
+  ) CNStakingV2Interface(newCnStaking) ProxyStakedKLAY(_feeTo, name, symbol) {}
 }

--- a/contracts/ProxyStakedKLAY.sol
+++ b/contracts/ProxyStakedKLAY.sol
@@ -38,6 +38,8 @@ abstract contract ProxyStakedKLAY is
   ERC20ProgrammaticBalanceStats,
   Ownable
 {
+  error AlreadyInitialized();
+
   constructor(
     address _feeTo,
     string memory name,
@@ -141,5 +143,9 @@ abstract contract ProxyStakedKLAY is
     uint16 newFeeDenominator
   ) public override onlyOwner {
     super.setFee(newFeeTo, newFeeNumerator, newFeeDenominator);
+  }
+
+  function acceptRewardAddress() external onlyOwner {
+    _acceptRewardAddress();
   }
 }

--- a/contracts/ProxyStakedKLAY.sol
+++ b/contracts/ProxyStakedKLAY.sol
@@ -142,6 +142,8 @@ abstract contract ProxyStakedKLAY is
     uint16 newFeeNumerator,
     uint16 newFeeDenominator
   ) public override onlyOwner {
+    sweep();
+
     super.setFee(newFeeTo, newFeeNumerator, newFeeDenominator);
   }
 

--- a/contracts/ProxyStakedKLAYClaimCheck.sol
+++ b/contracts/ProxyStakedKLAYClaimCheck.sol
@@ -19,9 +19,12 @@ import './ProxyStakedKLAY.sol';
  * @author Swapscanner
  * @notice Claim check represents unstaking requests for {ProxyStakedKLAYUnstakeable}.
  *
- * This contract should be deployed by an EOA in order to be registered and managed on OpenSea, ...
+ * This contract should be Ownable in order to be registered and managed on OpenSea, ...
+ * Owner will not be able to do anything except for transferring ownership.
  */
 contract ProxyStakedKLAYClaimCheck is IProxyStakedKLAYClaimCheck, ERC721Enumerable, Ownable {
+  error NotStakedKLAY();
+
   ProxyStakedKLAY public immutable staking;
   string private _svgTitle;
 
@@ -33,14 +36,18 @@ contract ProxyStakedKLAYClaimCheck is IProxyStakedKLAYClaimCheck, ERC721Enumerab
   ) ERC721(name, symbol) Ownable() {
     staking = _staking;
     _svgTitle = svgTitle_;
-    transferOwnership(address(_staking));
   }
 
-  function mint(address to, uint256 tokenId) external onlyOwner {
+  modifier onlyStaking() {
+    if (_msgSender() != address(staking)) revert NotStakedKLAY();
+    _;
+  }
+
+  function mint(address to, uint256 tokenId) external onlyStaking {
     _mint(to, tokenId);
   }
 
-  function burn(uint256 tokenId) external onlyOwner {
+  function burn(uint256 tokenId) external onlyStaking {
     _burn(tokenId);
   }
 

--- a/contracts/ProxyStakedKLAYUnstakeable.sol
+++ b/contracts/ProxyStakedKLAYUnstakeable.sol
@@ -73,6 +73,8 @@ abstract contract ProxyStakedKLAYUnstakeable is ProxyStakedKLAY {
     _processWithdrawalRequest(claimCheckTokenId);
   }
 
+  // This function is reentrancy-safe since claimCheck.burn will revert on reentrancy.
+  // slither-disable-next-line reentrancy-benign
   function _processWithdrawalRequest(uint256 claimCheckTokenId) private {
     address claimCheckOwner = claimCheck.ownerOf(claimCheckTokenId);
     if (

--- a/contracts/ProxyStakedKLAYUnstakeable.sol
+++ b/contracts/ProxyStakedKLAYUnstakeable.sol
@@ -14,7 +14,7 @@ import './ProxyStakedKLAYClaimCheck.sol';
  * Minted {ProxyStakedKLAYClaimCheck} token can be claimed or cancelled through this contract.
  */
 abstract contract ProxyStakedKLAYUnstakeable is ProxyStakedKLAY {
-  error AlreadyInitialized();
+  error InvalidSender();
 
   ProxyStakedKLAYClaimCheck public claimCheck;
 
@@ -99,5 +99,9 @@ abstract contract ProxyStakedKLAYUnstakeable is ProxyStakedKLAY {
     }
 
     sweep();
+  }
+
+  receive() external payable virtual {
+    if (_msgSender() != _cnStaking()) revert InvalidSender();
   }
 }

--- a/contracts/cnstakinginterfaces/CNStakingInterface.sol
+++ b/contracts/cnstakinginterfaces/CNStakingInterface.sol
@@ -18,6 +18,10 @@ abstract contract CNStakingInterface {
     virtual
     returns (uint256 amount, uint256 withdrawableFrom, WithdrawalRequestState state);
 
+  function _cnStaking() internal view virtual returns (address);
+
+  function _acceptRewardAddress() internal virtual;
+
   function _nextWithdrawalRequestId() internal virtual returns (uint256);
 
   function _submitWithdrawalRequest(uint256 amount) internal virtual;

--- a/contracts/cnstakinginterfaces/CNStakingV1Interface.sol
+++ b/contracts/cnstakinginterfaces/CNStakingV1Interface.sol
@@ -33,8 +33,8 @@ abstract contract CNStakingV1Interface is CNStakingInterface {
   CnStakingContract public immutable cnStaking;
   uint256 private _unstaking;
 
-  constructor(CnStakingContract _cnStaking) {
-    cnStaking = _cnStaking;
+  constructor(CnStakingContract newCnStaking) {
+    cnStaking = newCnStaking;
   }
 
   function withdrawalRequestTTL() public view virtual override returns (uint256) {
@@ -62,6 +62,14 @@ abstract contract CNStakingV1Interface is CNStakingInterface {
     } else if (_state == CnStakingContract.WithdrawalStakingState.Canceled) {
       state = WithdrawalRequestState.Cancelled;
     }
+  }
+
+  function _cnStaking() internal view override returns (address) {
+    return address(cnStaking);
+  }
+
+  function _acceptRewardAddress() internal virtual override {
+    // CNStakingV1 does not mandate to accept reward address.
   }
 
   function _nextWithdrawalRequestId() internal view virtual override returns (uint256) {

--- a/contracts/cnstakinginterfaces/CNStakingV2Interface.sol
+++ b/contracts/cnstakinginterfaces/CNStakingV2Interface.sol
@@ -20,6 +20,10 @@ abstract contract CNStakingV2Interface is CNStakingV1Interface {
     return CnStakingV2(payable(address(cnStaking))).STAKE_LOCKUP();
   }
 
+  function _acceptRewardAddress() internal virtual override {
+    CnStakingV2(payable(address(cnStaking))).acceptRewardAddress(address(this));
+  }
+
   // we do not have to track unstaking amount since CnStakingV2 does it for us.
 
   function _increaseUnstakingAmount(uint256 amount) internal virtual override {}

--- a/contracts/cnstakinginterfaces/CNStakingV2Interface.sol
+++ b/contracts/cnstakinginterfaces/CNStakingV2Interface.sol
@@ -13,8 +13,8 @@ import './CNStakingV1Interface.sol';
  */
 abstract contract CNStakingV2Interface is CNStakingV1Interface {
   constructor(
-    CnStakingV2 _cnStaking
-  ) CNStakingV1Interface(CnStakingContract(payable(address(_cnStaking)))) {}
+    CnStakingV2 newCnStaking
+  ) CNStakingV1Interface(CnStakingContract(payable(address(newCnStaking)))) {}
 
   function withdrawalRequestTTL() public view override returns (uint256) {
     return CnStakingV2(payable(address(cnStaking))).STAKE_LOCKUP();

--- a/contracts/crytic/echidna/E2E.sol
+++ b/contracts/crytic/echidna/E2E.sol
@@ -128,6 +128,10 @@ contract E2E {
 
   receive() external payable {}
 
+  function setFee(address newFeeTo, uint16 newFeeNumerator, uint16 newFeeDenominator) public {
+    cnStakedKLAY.setFee(newFeeTo, newFeeNumerator, newFeeDenominator);
+  }
+
   function testTotalShares(address account) public view {
     assert(cnStakedKLAY.sharesOf(account) <= cnStakedKLAY.totalShares());
   }
@@ -161,6 +165,7 @@ contract E2E {
   }
 
   function testStake() public payable {
+    uint256 beforeShare = cnStakedKLAY.sharesOf(address(this));
     uint256 beforeBalance = cnStakedKLAY.balanceOf(address(this));
     uint256 amount = msg.value;
 
@@ -168,11 +173,45 @@ contract E2E {
       assert(false);
     }
 
+    uint256 afterShare = cnStakedKLAY.sharesOf(address(this));
     uint256 afterBalance = cnStakedKLAY.balanceOf(address(this));
+
     assert(afterBalance >= beforeBalance + amount - 1);
+    if (msg.value > 1) {
+      assert(afterShare > beforeShare);
+    }
+  }
+
+  function testStakeWithSweep() public payable {
+    cnStakedKLAY.sweep();
+
+    uint256 beforeShare = cnStakedKLAY.sharesOf(address(this));
+    uint256 beforeBalance = cnStakedKLAY.balanceOf(address(this));
+    uint256 amount = msg.value;
+    uint256 beforeTotalShares = cnStakedKLAY.totalShares();
+    uint256 beforeTotalSupply = cnStakedKLAY.totalSupply();
+
+    try cnStakedKLAY.stake{value: amount}() {} catch {
+      assert(false);
+    }
+
+    uint256 afterShare = cnStakedKLAY.sharesOf(address(this));
+    uint256 afterBalance = cnStakedKLAY.balanceOf(address(this));
+    uint256 afterTotalShares = cnStakedKLAY.totalShares();
+    uint256 afterTotalSupply = cnStakedKLAY.totalSupply();
+
+    assert(afterBalance >= beforeBalance + amount - 1);
+    assert(afterTotalSupply >= beforeTotalSupply + amount - 1);
+    if (msg.value > 1) {
+      assert(afterShare > beforeShare);
+      assert(afterTotalShares > beforeTotalShares);
+    } else {
+      assert(afterTotalShares >= beforeTotalShares);
+    }
   }
 
   function testStakeFor() public payable {
+    uint256 beforeShare = cnStakedKLAY.sharesOf(address(this));
     uint256 beforeBalance = cnStakedKLAY.balanceOf(address(this));
     uint256 amount = msg.value;
 
@@ -180,11 +219,16 @@ contract E2E {
       assert(false);
     }
 
+    uint256 afterShare = cnStakedKLAY.sharesOf(address(this));
     uint256 afterBalance = cnStakedKLAY.balanceOf(address(this));
     assert(afterBalance >= beforeBalance + amount - 1);
+    if (msg.value > 1) {
+      assert(afterShare > beforeShare);
+    }
   }
 
   function testUnstake(uint256 amount) public {
+    uint256 beforeShare = cnStakedKLAY.sharesOf(address(this));
     uint256 beforeBalance = cnStakedKLAY.balanceOf(address(this));
     require(amount <= beforeBalance, 'amount must be less than balance');
     require(amount > 0, 'amount must be greater than 0');
@@ -195,8 +239,36 @@ contract E2E {
       assert(desiredSelector == receivedSelector);
     }
 
+    uint256 afterShare = cnStakedKLAY.sharesOf(address(this));
     uint256 afterBalance = cnStakedKLAY.balanceOf(address(this));
-    assert(afterBalance < beforeBalance);
+    assert(afterShare < beforeShare);
+    assert(afterBalance <= beforeBalance - amount + 1);
+  }
+
+  function testUnstakeWithSweep(uint256 amount) public {
+    cnStakedKLAY.sweep();
+
+    uint256 beforeShare = cnStakedKLAY.sharesOf(address(this));
+    uint256 beforeBalance = cnStakedKLAY.balanceOf(address(this));
+    uint256 beforeTotalShares = cnStakedKLAY.totalShares();
+    uint256 beforeTotalSupply = cnStakedKLAY.totalSupply();
+    require(amount <= beforeBalance, 'amount must be less than balance');
+    require(amount > 0, 'amount must be greater than 0');
+
+    try cnStakedKLAY.unstake(amount) {} catch (bytes memory reason) {
+      bytes4 desiredSelector = bytes4(keccak256(bytes('AmountTooSmall()')));
+      bytes4 receivedSelector = bytes4(reason);
+      assert(desiredSelector == receivedSelector);
+    }
+
+    uint256 afterShare = cnStakedKLAY.sharesOf(address(this));
+    uint256 afterBalance = cnStakedKLAY.balanceOf(address(this));
+    uint256 afterTotalShares = cnStakedKLAY.totalShares();
+    uint256 afterTotalSupply = cnStakedKLAY.totalSupply();
+    assert(afterShare < beforeShare);
+    assert(afterBalance <= beforeBalance - amount + 1);
+    assert(afterTotalShares < beforeTotalShares);
+    assert(afterTotalSupply <= beforeTotalSupply - amount + 1);
   }
 
   function testUnstakeAll() public {
@@ -210,7 +282,80 @@ contract E2E {
     }
 
     uint256 afterBalance = cnStakedKLAY.balanceOf(address(this));
+    uint256 afterShare = cnStakedKLAY.sharesOf(address(this));
     assert(afterBalance == 0);
+    assert(afterShare == 0);
+  }
+
+  function testTransfer(uint256 amount, address toAccount) public {
+    require(address(this) != address(0), 'this must not be 0x0');
+    require(toAccount != address(0), 'toAccount must not be 0x0');
+    require(toAccount != address(this), 'toAccount must not be this');
+
+    uint256 beforeFromBalance = cnStakedKLAY.balanceOf(address(this));
+    uint256 beforeFromShare = cnStakedKLAY.sharesOf(address(this));
+    require(amount <= beforeFromBalance, 'amount must be less than balance');
+    require(amount > 0, 'amount must be greater than 0');
+    uint256 beforeToBalance = cnStakedKLAY.balanceOf(toAccount);
+    uint256 beforeToShare = cnStakedKLAY.sharesOf(toAccount);
+
+    try cnStakedKLAY.transfer(toAccount, amount) {} catch (bytes memory reason) {
+      bytes4 desiredSelector = bytes4(keccak256('AmountTooSmall()'));
+      bytes4 receivedSelector = bytes4(reason);
+      assert(desiredSelector == receivedSelector);
+    }
+
+    uint256 afterFromBalance = cnStakedKLAY.balanceOf(address(this));
+    uint256 afterFromShare = cnStakedKLAY.sharesOf(address(this));
+    uint256 afterToBalance = cnStakedKLAY.balanceOf(toAccount);
+    uint256 afterToShare = cnStakedKLAY.sharesOf(toAccount);
+
+    assert(afterFromBalance <= beforeFromBalance - amount + 1);
+    assert(afterFromShare < beforeFromShare);
+    assert(afterToBalance >= beforeToBalance + amount - 1);
+    assert(afterToShare > beforeToShare);
+    if (toAccount == cnStakedKLAY.feeTo()) {
+      assert(beforeFromShare + beforeToShare <= afterFromShare + afterToShare);
+    } else {
+      assert(beforeFromShare + beforeToShare == afterFromShare + afterToShare);
+    }
+  }
+
+  function testTransferWithSweep(uint256 amount, address toAccount) public {
+    require(address(this) != address(0), 'this must not be 0x0');
+    require(toAccount != address(0), 'toAccount must not be 0x0');
+    require(toAccount != address(this), 'toAccount must not be this');
+
+    // sweep reward to prevent totalShares, totalSupply from being changed
+    cnStakedKLAY.sweep();
+
+    uint256 beforeFromBalance = cnStakedKLAY.balanceOf(address(this));
+    uint256 beforeFromShare = cnStakedKLAY.sharesOf(address(this));
+    require(amount <= beforeFromBalance, 'amount must be less than balance');
+    require(amount > 0, 'amount must be greater than 0');
+    uint256 beforeToBalance = cnStakedKLAY.balanceOf(toAccount);
+    uint256 beforeToShare = cnStakedKLAY.sharesOf(toAccount);
+    uint256 beforeTotalShares = cnStakedKLAY.totalShares();
+    uint256 beforeTotalSupply = cnStakedKLAY.totalSupply();
+
+    try cnStakedKLAY.transfer(toAccount, amount) {} catch {
+      assert(false);
+    }
+
+    uint256 afterFromBalance = cnStakedKLAY.balanceOf(address(this));
+    uint256 afterFromShare = cnStakedKLAY.sharesOf(address(this));
+    uint256 afterToBalance = cnStakedKLAY.balanceOf(toAccount);
+    uint256 afterToShare = cnStakedKLAY.sharesOf(toAccount);
+    uint256 afterTotalShares = cnStakedKLAY.totalShares();
+    uint256 afterTotalSupply = cnStakedKLAY.totalSupply();
+
+    assert(afterFromBalance <= beforeFromBalance - amount + 1);
+    assert(afterFromShare < beforeFromShare);
+    assert(afterToBalance >= beforeToBalance + amount - 1);
+    assert(afterToShare > beforeToShare);
+    assert(beforeFromShare + beforeToShare == afterFromShare + afterToShare);
+    assert(afterTotalShares == beforeTotalShares);
+    assert(afterTotalSupply == beforeTotalSupply);
   }
 
   function _getRandomTokenId(uint256 input) internal view returns (uint256) {

--- a/contracts/external/klaytn/cnstakingv2/CnStakingV2.sol
+++ b/contracts/external/klaytn/cnstakingv2/CnStakingV2.sol
@@ -790,7 +790,9 @@ contract CnStakingV2 is ICnStakingV2 {
     ///
     /// Note that This fallback only accept transactions with empty calldata.
     /// contract calls with wrong function signature is reverted despite this fallback.
-    receive() external payable override
+    ///
+    /// @dev SWAPSCANNER NOTE: This function is NOT `virtual` on the actual contract.
+    receive() external virtual payable override
     afterInit() {
         stakeKlay();
     }

--- a/contracts/test/AddressBookMock.sol
+++ b/contracts/test/AddressBookMock.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity =0.8.18;
+
+import '../external/klaytn/cnstakingv2/CnStakingV2.sol';
+
+contract AddressBookMock is IAddressBook {
+  event ReviseRewardAddress(address a);
+
+  function getState() external pure returns (address[] memory, uint256) {
+    return (new address[](0), 0);
+  }
+
+  function reviseRewardAddress(address a) external {
+    emit ReviseRewardAddress(a);
+  }
+}

--- a/contracts/test/CNStakedKLAYV1Mock.sol
+++ b/contracts/test/CNStakedKLAYV1Mock.sol
@@ -15,6 +15,4 @@ contract CNStakedKLAYV1Mock is CNStakedKLAYV1 {
     address _feeTo,
     CnStakingContract _cnStaking
   ) CNStakedKLAYV1('CNStakedKLAYV1Mock', 'msKLAY', _feeTo, _cnStaking) {}
-
-  receive() external payable {}
 }

--- a/contracts/test/CNStakedKLAYV2Mock.sol
+++ b/contracts/test/CNStakedKLAYV2Mock.sol
@@ -15,6 +15,4 @@ contract CNStakedKLAYV2Mock is CNStakedKLAYV2 {
     address _feeTo,
     CnStakingV2 _cnStaking
   ) CNStakedKLAYV2('CNStakedKLAYV2Mock', 'msKLAY', _feeTo, _cnStaking) {}
-
-  receive() external payable {}
 }

--- a/test/ProxyStakedKLAY.ts
+++ b/test/ProxyStakedKLAY.ts
@@ -1,16 +1,10 @@
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
-import {
-  CNStakedKLAYV2,
-  CNStakedKLAYV2Mock,
-  CnStakingV2,
-  ProxyStakedKLAYClaimCheck,
-} from '../typechain-types';
+import { CNStakedKLAYV2Mock, CnStakingV2, ProxyStakedKLAYClaimCheck } from '../typechain-types';
 import { useSnapshot } from './utils/useSnapshot';
 import { useLogger } from './utils/useLogger';
 import { BigNumber, BigNumberish } from 'ethers';
-import { TransactionResponse } from '@ethersproject/providers';
 import { expectEtherBalanceOf } from './utils/balanceAssertions';
 import { Accounts } from './utils/accounts';
 import { AccountsConnectedContract } from './utils/accountsConnectedContract';

--- a/test/utils/setupCNStakedKLAY.ts
+++ b/test/utils/setupCNStakedKLAY.ts
@@ -1,11 +1,6 @@
 import { ethers } from 'hardhat';
 import { deployAccountsConnectedContract } from './accountsConnectedContract';
-import {
-  AddressBookMock,
-  CNStakedKLAYV2Mock,
-  CnStakingV2,
-  ProxyStakedKLAYClaimCheck,
-} from '../../typechain-types';
+import { CNStakedKLAYV2Mock, CnStakingV2, ProxyStakedKLAYClaimCheck } from '../../typechain-types';
 import { makeEveryoneRich } from './makeEveryoneRich';
 
 export type AccountName =


### PR DESCRIPTION
This PR:
- implements the ability for `ProxyStakedKLAY` to accept reward address change (introduced in `CnStakingV2`).
- only allows `CnStakingV2` to send KLAY to `ProxyStakedKLAYUnstakeable`.
- adds test for above cases.
- fix slither analysis issues.
- make `ProxyStakedKLAYClaimCheck` be able to owned by external account, where Owner cannot do anything effectively (details in comment).
- make `ProxyStakedKLAY` to sweep before fee update.
- adds more E2E echidna assertions.