### PR TITLE
contracts(CNStakingV2Interface): accept reward addr from random cn

### DIFF
--- a/contracts/ProxyStakedKLAY.sol
+++ b/contracts/ProxyStakedKLAY.sol
@@ -147,7 +147,7 @@ abstract contract ProxyStakedKLAY is
     super.setFee(newFeeTo, newFeeNumerator, newFeeDenominator);
   }
 
-  function acceptRewardAddress() external onlyOwner {
-    _acceptRewardAddress();
+  function acceptRewardAddress(address cnStakingAddress) external onlyOwner {
+    _acceptRewardAddress(cnStakingAddress);
   }
 }

--- a/contracts/cnstakinginterfaces/CNStakingInterface.sol
+++ b/contracts/cnstakinginterfaces/CNStakingInterface.sol
@@ -20,7 +20,7 @@ abstract contract CNStakingInterface {
 
   function _cnStaking() internal view virtual returns (address);
 
-  function _acceptRewardAddress() internal virtual;
+  function _acceptRewardAddress(address cnStakingAddress) internal virtual;
 
   function _nextWithdrawalRequestId() internal virtual returns (uint256);
 

--- a/contracts/cnstakinginterfaces/CNStakingV1Interface.sol
+++ b/contracts/cnstakinginterfaces/CNStakingV1Interface.sol
@@ -68,7 +68,7 @@ abstract contract CNStakingV1Interface is CNStakingInterface {
     return address(cnStaking);
   }
 
-  function _acceptRewardAddress() internal virtual override {
+  function _acceptRewardAddress(address cnStakingAddress) internal virtual override {
     // CNStakingV1 does not mandate to accept reward address.
   }
 

--- a/contracts/cnstakinginterfaces/CNStakingV2Interface.sol
+++ b/contracts/cnstakinginterfaces/CNStakingV2Interface.sol
@@ -20,8 +20,8 @@ abstract contract CNStakingV2Interface is CNStakingV1Interface {
     return CnStakingV2(payable(address(cnStaking))).STAKE_LOCKUP();
   }
 
-  function _acceptRewardAddress() internal virtual override {
-    CnStakingV2(payable(address(cnStaking))).acceptRewardAddress(address(this));
+  function _acceptRewardAddress(address cnStakingAddress) internal virtual override {
+    CnStakingV2(payable(cnStakingAddress)).acceptRewardAddress(address(this));
   }
 
   // we do not have to track unstaking amount since CnStakingV2 does it for us.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swapscanner/klaystaking-core",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "files": [
     "/contracts/**/*.sol",
     "/build/contracts/*.json",


### PR DESCRIPTION
There could be a use case where multiple `CnStakingV2`s' reward address point to the same `CNStakingV2Interface`.